### PR TITLE
Add IP based starting location and restore state

### DIFF
--- a/QualtricsGoogleMapLatLong.js
+++ b/QualtricsGoogleMapLatLong.js
@@ -68,10 +68,16 @@ Qualtrics.SurveyEngine.addOnload(function() {
 
     // Need to be able to access the marker to update it later.
     var marker;
-    
+
+    // Check for existing question value and set starting marker accordingly
     if(dataBox.value != ""){
-        startPlace = new google.maps.LatLng(dataBox.value.evalJSON().lat,dataBox.value.evalJSON().long);
-        geocoderRequest = {'location': startPlace};
+		try{
+			startPlace = new google.maps.LatLng(dataBox.value.evalJSON().lat,dataBox.value.evalJSON().long);
+			geocoderRequest = {'location': startPlace};
+		} catch(err){
+			console.log("Unable to parse existing question value: " + err);
+		}
+		
     }
 
     if (enableAutocompleteField) {

--- a/QualtricsGoogleMapLatLong.js
+++ b/QualtricsGoogleMapLatLong.js
@@ -1,10 +1,11 @@
 /*
  * Qualtrics Google Map Lat/Long Collector
  *
- * Written by George Walker <george@georgewwalker.com>
- * Get the latest from GitHub: https://github.com/pkmnct/qualtrics-google-map-lat-long/
+ * Written by Carlos Barahona
+ * based most on code writen by George Walker <george@georgewwalker.com>
+ * Get the latest from GitHub: https://github.com/guatemaleco/qualtrics-google-map-lat-long/
  *
- * Last changed April 7, 2018.
+ * Last changed October 13, 2018.
  *
  * This JavaScript allows a Qualtrics user to collect a lat/long from a
  * Google Map in a survey. To use it, create a new "Text Entry" question,
@@ -43,8 +44,10 @@ Qualtrics.SurveyEngine.addOnload(function() {
     // Variables:
     var mapCenterLat = 39.1836;
     var mapCenterLng = -96.5717;
-    var mapZoom = 16; // See https://developers.google.com/maps/documentation/javascript/tutorial#zoom-levels for help.
+    var mapZoom = 11; // See https://developers.google.com/maps/documentation/javascript/tutorial#zoom-levels for help.
     var pinTitle = "Move pin to correct location"; // This is displayed when hovering over the pin on the map.
+    var startPlace = "${loc://PostalCode}";
+    var geocoderRequest = {'address': startPlace};
 
 
     var mapWidth = "100%";
@@ -65,6 +68,11 @@ Qualtrics.SurveyEngine.addOnload(function() {
 
     // Need to be able to access the marker to update it later.
     var marker;
+    
+    if(dataBox.value != ""){
+        startPlace = new google.maps.LatLng(dataBox.value.evalJSON().lat,dataBox.value.evalJSON().long);
+        geocoderRequest = {'location': startPlace};
+    }
 
     if (enableAutocompleteField) {
         // Create a search box
@@ -137,6 +145,20 @@ Qualtrics.SurveyEngine.addOnload(function() {
                 map: map,
                 title: pinTitle
             });
+            
+            //Update marker with IP based location
+            var geocoder = new google.maps.Geocoder();
+            geocoder.geocode(geocoderRequest, function(results, status) {
+                if (status === 'OK') {
+                    
+                  map.setCenter(results[0].geometry.location);
+                  var latlng = new google.maps.LatLng(results[0].geometry.location.lat(),results[0].geometry.location.lng());
+                  marker.setPosition(latlng);
+                } else {
+                    alert('Geocode was not successful for the following reason: ' + status);
+                }
+              });
+              
 
             // When the pin is clicked, store the lat/lng
             google.maps.event.addListener(marker, 'click', function(event) {

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ On the left side of the question, click the gear and select _Add JavaScript..._
 
 Select everything in the box and clear it. The JavaScript box should be empty before pasting the code.
 
-Copy the JavaScript from the [file](https://github.com/pkmnct/qualtrics-google-map-lat-long/blob/master/QualtricsGoogleMapLatLong.js) and paste it in the box.
+Copy the JavaScript from the [file](./QualtricsGoogleMapLatLong.js) and paste it in the box.
 
 At the top of the pasted code, find the section labeled _Enter your Google Map API key in this variable._
 


### PR DESCRIPTION
Initial marker on unanswered questions set to geolocated IP location.

Browsing back to an answered question did not restore marker location. This sets marker location based on existing question value.